### PR TITLE
WebRTC No SRLFX or Host Candidate

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const puppeteer = require('puppeteer');
 
 (async () => {
-  const browser = await puppeteer.launch();
+  const browser = await puppeteer.launch({args: ["--disable-features=WebRtcHideLocalIpsWithMdns"]});
   const page = await browser.newPage();
   await page.goto('https://haxball.com/headless', { waitUntil: 'networkidle2' });
 


### PR DESCRIPTION
It can be useful add args to bypass browser block: I tried to connect to my hosted room using script and I got connection error then I added --disable-features=WebRtcHideLocalIpsWithMdns arg to bypass it.